### PR TITLE
Add condition to exclude dependabot from wip-action

### DIFF
--- a/.github/workflows/wip.yml
+++ b/.github/workflows/wip.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   wip:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: wip/action@v1.1.1
         env:


### PR DESCRIPTION
`Dependabot auto-merge `が、wipで詰まるので、
`dependabot[bot]`は、wipをskipさせるようにしました。